### PR TITLE
A space is required between # and the headline to show properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/json-markdown",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Generate Markdown documentation for your JSON schema",
   "main": "index.js",
   "scripts": {

--- a/src/generator/markdown.js
+++ b/src/generator/markdown.js
@@ -22,7 +22,7 @@ objectAssign(Markdown.prototype, {
 
   headline(string, size) {
     const headline = new Array((size || 1) + 1).join('#');
-    this.lines.push(headline + string, '');
+    this.lines.push(headline + ' ' + string, '');
   },
 
   description(string) {

--- a/src/generator/markdown.js
+++ b/src/generator/markdown.js
@@ -22,7 +22,7 @@ objectAssign(Markdown.prototype, {
 
   headline(string, size) {
     const headline = new Array((size || 1) + 1).join('#');
-    this.lines.push(headline + ' ' + string, '');
+    this.lines.push(`${headline} ${string}`, '');
   },
 
   description(string) {


### PR DESCRIPTION
Before:
`####Type: object`

####Type: object

After:
`#### Type: object`
#### Type: object

This is done in the original repo: https://github.com/joxoo/jsonschema-md/blob/master/src/generator/markdown.js#L24